### PR TITLE
Creates two distinct jobs queues

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -2,4 +2,8 @@ class Asset < ApplicationRecord
   validates :symbol, presence: true, uniqueness: true
 
   has_one :last_quote, -> { where(quotes: { current: true }) }, class_name: 'Quote'
+  has_many :wallet_items
+
+  scope :in_wallet, -> { left_joins(:wallet_items).distinct.where.not(wallet_items: { id: nil }) }
+  scope :not_in_wallet, -> { left_joins(:wallet_items).distinct.where(wallet_items: { id: nil }) }
 end

--- a/app/services/assets_price_updater.rb
+++ b/app/services/assets_price_updater.rb
@@ -11,7 +11,6 @@ class AssetsPriceUpdater
       default: Asset.not_in_wallet.pluck(:symbol),
       in_wallet: Asset.in_wallet.pluck(:symbol)
     }
-
     queues.each do |queue, symbols|
       symbols.each do |symbol|
         UpdateQuoteJob.set(queue: queue).perform_async(symbol)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,3 +1,6 @@
+:queues:
+  - in_wallet
+  - default
 :schedule:
   update_quote:
     cron: "*/5 * * * *"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user do
+    sequence(:email) { |n| "test#{n}@.sdf.com" }
+    password { '123456' }
+  end
+end

--- a/spec/factories/wallet_items.rb
+++ b/spec/factories/wallet_items.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :wallet_item do
+    wallet
+    asset
+  end
+end

--- a/spec/factories/wallets.rb
+++ b/spec/factories/wallets.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :wallet do
+    user
+  end
+end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Asset, type: :model do
+  let!(:user) { create(:user) }
+  let!(:wallet) { create(:wallet, user: user) }
+  let!(:assets) { create_list(:asset, 5) }
+  let!(:wallet_items) do
+    create(:wallet_item, asset: assets.first, wallet: wallet)
+    create(:wallet_item, asset: assets.second, wallet: wallet)
+  end
+
+  it 'return asset in wallets' do
+    expect(Asset.in_wallet.to_a).to match_array(assets[..1])
+  end
+  it 'returns assets not in wallets' do
+    expect(Asset.not_in_wallet.to_a).to match_array(assets[2..])
+  end
+end

--- a/spec/services/asset_price_updater_spec.rb
+++ b/spec/services/asset_price_updater_spec.rb
@@ -2,13 +2,37 @@ require 'rails_helper'
 
 RSpec.describe AssetsPriceUpdater do
   subject { AssetsPriceUpdater.call }
-  let!(:assets) { create_list(:asset, 5) }
 
-  it 'perform async jobs for each asset' do
-    allow(UpdateQuoteJob).to receive(:perform_async)
-    subject
-    assets.each do |asset|
-      expect(UpdateQuoteJob).to have_received(:perform_async).with(asset.symbol)
+  describe 'with 2 assets being used in wallet and 3 dont' do
+    let!(:user) { create(:user) }
+    let!(:wallet) { create(:wallet, user: user) }
+    let!(:assets) { create_list(:asset, 5) }
+    let!(:wallet_items) do
+      create(:wallet_item, asset: assets.first, wallet: wallet)
+      create(:wallet_item, asset: assets.second, wallet: wallet)
+    end
+
+    before(:each) do
+      allow(UpdateQuoteJob).to receive(:perform_async)
+      allow(UpdateQuoteJob).to receive(:set).and_return(UpdateQuoteJob)
+    end
+
+    it 'perform async jobs for each asset' do
+      subject
+
+      assets.each do |asset|
+        expect(UpdateQuoteJob).to have_received(:perform_async).with(asset.symbol)
+      end
+    end
+
+    it 'sends 2 jobs to in_wallet queue' do
+      subject
+      expect(UpdateQuoteJob).to have_received(:set).exactly(2).times.with(queue: :in_wallet)
+    end
+
+    it 'sends 3 jobs to default queue' do
+      subject
+      expect(UpdateQuoteJob).to have_received(:set).exactly(3).times.with(queue: :default)
     end
   end
 end


### PR DESCRIPTION
* Separates jobs in different priority queues. Update quote jobs whose assets are in wallets uses `in_wallet` queueu and they are updated first